### PR TITLE
DNS: fix eight RFC conformance deviations found by the conformance suite

### DIFF
--- a/Hermod/DNS/Client/DNSUDPClient.cs
+++ b/Hermod/DNS/Client/DNSUDPClient.cs
@@ -274,37 +274,63 @@ namespace org.GraphDefined.Vanaheimr.Hermod.DNS
                 await socket.SendToAsync(ms.ToArray(), SocketFlags.None, remoteEndPoint, timeoutCTS.Token).
                              ConfigureAwait(false);
 
-                var data      = new Byte[Math.Max(4096, (Int32) UDPPayloadSize)];
-                var received  = await socket.ReceiveAsync(data, SocketFlags.None, timeoutCTS.Token).
-                                             ConfigureAwait(false);
+                var data = new Byte[Math.Max(4096, (Int32) UDPPayloadSize)];
 
-                var response = DNSInfo.ReadResponse(
-                                  new DNSServerConfig(
-                                      RemoteIPAddress!,
-                                      RemotePort ?? IPPort.DNS,
-                                      DNSTransport.UDP,
-                                      effectiveTimeout
-                                  ),
-                                  dnsQuery.TransactionId,
-                                  new MemoryStream(data, 0, received),
-                                  effectiveTimeout,
-                                  stopwatch.Elapsed
-                              );
-
-                // RFC 5966: If the UDP response is truncated, retry via TCP
-                if (response.IsTruncated)
+                while (true)
                 {
-                    logger.LogDebug(
-                        "DNS UDP response from {RemoteIPAddress}:{RemotePort} was truncated; retrying via TCP",
-                        RemoteIPAddress,
-                        RemotePort
-                    );
 
-                    return await QueryViaTCPFallbackAsync(dnsQuery, effectiveTimeout, timeoutCTS.Token).
-                                     ConfigureAwait(false);
+                    var received = await socket.ReceiveAsync(data, SocketFlags.None, timeoutCTS.Token).
+                                                ConfigureAwait(false);
+
+                    // RFC 5452 §4.2: a resolver MUST ignore responses that do not
+                    // match the outstanding query. "Ignore" means keep waiting for
+                    // the genuine reply — treating the first datagram as final would
+                    // let any off-path attacker cancel a lookup with one forged
+                    // packet. The overall timeout still bounds the wait.
+                    if (received < 2 ||
+                        ((data[0] << 8) | data[1]) != dnsQuery.TransactionId)
+                    {
+
+                        logger.LogDebug(
+                            "Ignoring a DNS UDP datagram from {RemoteIPAddress}:{RemotePort} that does not match transaction id {TransactionId}",
+                            RemoteIPAddress,
+                            RemotePort,
+                            dnsQuery.TransactionId
+                        );
+
+                        continue;
+
+                    }
+
+                    var response = DNSInfo.ReadResponse(
+                                      new DNSServerConfig(
+                                          RemoteIPAddress!,
+                                          RemotePort ?? IPPort.DNS,
+                                          DNSTransport.UDP,
+                                          effectiveTimeout
+                                      ),
+                                      dnsQuery.TransactionId,
+                                      new MemoryStream(data, 0, received),
+                                      effectiveTimeout,
+                                      stopwatch.Elapsed
+                                  );
+
+                    // RFC 5966: If the UDP response is truncated, retry via TCP
+                    if (response.IsTruncated)
+                    {
+                        logger.LogDebug(
+                            "DNS UDP response from {RemoteIPAddress}:{RemotePort} was truncated; retrying via TCP",
+                            RemoteIPAddress,
+                            RemotePort
+                        );
+
+                        return await QueryViaTCPFallbackAsync(dnsQuery, effectiveTimeout, timeoutCTS.Token).
+                                         ConfigureAwait(false);
+                    }
+
+                    return response;
+
                 }
-
-                return response;
 
             }
             catch (SocketException se) when (se.SocketErrorCode == SocketError.AddressFamilyNotSupported)

--- a/Hermod/DNS/Helpers/DNSResponseCodes.cs
+++ b/Hermod/DNS/Helpers/DNSResponseCodes.cs
@@ -30,7 +30,14 @@ namespace org.GraphDefined.Vanaheimr.Hermod.DNS
         NameError       = 3, // NXDOMAIN
         NotImplemented  = 4,
         Refused         = 5,
-        Reserved        = 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15
+        Reserved        = 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15,
+
+        /// <summary>
+        /// Bad EDNS version (RFC 6891 §9). An extended RCODE: the low 4 bits
+        /// travel in the message header, the upper 8 in the OPT record's TTL
+        /// field, so this value only reaches the wire when an OPT is present.
+        /// </summary>
+        BadVersion      = 16
 
     }
 

--- a/Hermod/DNS/Helpers/DNSTools.cs
+++ b/Hermod/DNS/Helpers/DNSTools.cs
@@ -150,6 +150,54 @@ namespace org.GraphDefined.Vanaheimr.Hermod.DNS
 
         #endregion
 
+        #region ExtractCharacterStrings(Stream, RDLength)
+
+        /// <summary>
+        /// Read exactly RDLength octets of RDATA as a sequence of
+        /// &lt;character-string&gt;s (RFC 1035 §3.3).
+        /// </summary>
+        /// <remarks>
+        /// RDLENGTH delimits the RDATA (RFC 1035 §4.1.3), so the count of
+        /// character-strings follows from it — there is no terminator. Reading
+        /// beyond it would consume the following resource record; stopping
+        /// short would leave the stream misaligned for it.
+        /// </remarks>
+        /// <param name="Stream">A stream positioned at the start of the RDATA.</param>
+        /// <param name="RDLength">The RDATA length in octets, as read from the RDLENGTH field.</param>
+        public static IEnumerable<String> ExtractCharacterStrings(Stream  Stream,
+                                                                  Int32   RDLength)
+        {
+
+            var strings    = new List<String>();
+            var remaining  = RDLength;
+
+            while (remaining > 0)
+            {
+
+                var length = Stream.ReadByte();
+
+                if (length < 0)
+                    throw new EndOfStreamException("Unexpected end of stream while reading a character-string!");
+
+                remaining--;
+
+                if (length > remaining)
+                    throw new InvalidDataException($"character-string of {length} bytes exceeds the {remaining} bytes remaining within RDLENGTH!");
+
+                var buffer = new Byte[length];
+                Stream.ReadExactly(buffer, 0, length);
+
+                strings.Add(Encoding.ASCII.GetString(buffer));
+                remaining -= length;
+
+            }
+
+            return strings;
+
+        }
+
+        #endregion
+
         #region ExtractCharacterStrings(Stream)
 
         public static IEnumerable<String> ExtractCharacterStrings(Stream Stream)

--- a/Hermod/DNS/ResourceRecords/HTTPS.cs
+++ b/Hermod/DNS/ResourceRecords/HTTPS.cs
@@ -122,47 +122,16 @@ namespace org.GraphDefined.Vanaheimr.Hermod.DNS
 
         {
 
-            this.Priority    = (UInt16) ((Stream.ReadByte() & byte.MaxValue) << 8 | Stream.ReadByte() & byte.MaxValue);
-            this.TargetName  = DNSTools.ExtractDomainName(Stream);
+            var rdLength       = Stream.ReadUInt16BE();
+            var rdataStart     = Stream.Position;
 
-            var svcParams    = new List<SVCParameter>();
+            this.Priority      = Stream.ReadUInt16BE();
+            this.TargetName    = DNSTools.ExtractDomainName(Stream);
 
-            while (true)
-            {
-
-                var b1 = Stream.ReadByte();
-
-                if (b1 == -1)
-                    break;
-
-                var b2 = Stream.ReadByte();
-
-                if (b2 == -1)
-                    break;
-
-                var key = (UInt16) ((b1 << 8) | b2);
-                b1 = Stream.ReadByte();
-                b2 = Stream.ReadByte();
-
-                if (b2 == -1)
-                    break;
-
-                var len   = (UInt16) ((b1 << 8) | b2);
-                var value = new Byte[len];
-
-                if (Stream.Read(value, 0, len) != len)
-                    break;
-
-                svcParams.Add(
-                    new SVCParameter(
-                        key,
-                        value
-                    )
-                );
-
-            }
-
-            this.SVCParameters = svcParams.AsReadOnly();
+            this.SVCParameters = SVCB.ParseSVCParameters(
+                                     Stream,
+                                     rdLength - (Int32) (Stream.Position - rdataStart)
+                                 ).AsReadOnly();
 
         }
 
@@ -184,49 +153,16 @@ namespace org.GraphDefined.Vanaheimr.Hermod.DNS
 
         {
 
-            var rdLength = Stream.ReadUInt16BE();
+            var rdLength       = Stream.ReadUInt16BE();
+            var rdataStart     = Stream.Position;
 
-            this.Priority    = (UInt16) ((Stream.ReadByte() & byte.MaxValue) << 8 | Stream.ReadByte() & byte.MaxValue);
-            this.TargetName  = DNSTools.ExtractDomainName(Stream);
+            this.Priority      = Stream.ReadUInt16BE();
+            this.TargetName    = DNSTools.ExtractDomainName(Stream);
 
-            var svcParams    = new List<SVCParameter>();
-
-            while (true)
-            {
-
-                var b1 = Stream.ReadByte();
-
-                if (b1 == -1)
-                    break;
-
-                var b2 = Stream.ReadByte();
-
-                if (b2 == -1)
-                    break;
-
-                var key = (UInt16) ((b1 << 8) | b2);
-                b1 = Stream.ReadByte();
-                b2 = Stream.ReadByte();
-
-                if (b2 == -1)
-                    break;
-
-                var len   = (UInt16) ((b1 << 8) | b2);
-                var value = new Byte[len];
-
-                if (Stream.Read(value, 0, len) != len)
-                    break;
-
-                svcParams.Add(
-                    new SVCParameter(
-                        key,
-                        value
-                    )
-                );
-
-            }
-
-            this.SVCParameters = svcParams.AsReadOnly();
+            this.SVCParameters = SVCB.ParseSVCParameters(
+                                     Stream,
+                                     rdLength - (Int32) (Stream.Position - rdataStart)
+                                 ).AsReadOnly();
 
         }
 

--- a/Hermod/DNS/ResourceRecords/SPF.cs
+++ b/Hermod/DNS/ResourceRecords/SPF.cs
@@ -109,7 +109,11 @@ namespace org.GraphDefined.Vanaheimr.Hermod.DNS
 
         {
 
-            this.Rules = DNSTools.ExtractName(Stream);
+            var rdLength = Stream.ReadUInt16BE();
+
+            // RFC 7208 §3.1: SPF shares the TXT RDATA format — one or more
+            // <character-string>s, concatenated. It is not a domain name.
+            this.Rules = String.Concat(DNSTools.ExtractCharacterStrings(Stream, rdLength));
 
         }
 
@@ -133,7 +137,9 @@ namespace org.GraphDefined.Vanaheimr.Hermod.DNS
 
             var rdLength = Stream.ReadUInt16BE();
 
-            this.Rules = DNSTools.ExtractName(Stream);
+            // RFC 7208 §3.1: SPF shares the TXT RDATA format — one or more
+            // <character-string>s, concatenated. It is not a domain name.
+            this.Rules = String.Concat(DNSTools.ExtractCharacterStrings(Stream, rdLength));
 
         }
 

--- a/Hermod/DNS/ResourceRecords/SVCB.cs
+++ b/Hermod/DNS/ResourceRecords/SVCB.cs
@@ -148,6 +148,55 @@ namespace org.GraphDefined.Vanaheimr.Hermod.DNS
 
         #endregion
 
+        #region (internal static) ParseSVCParameters(Stream, RemainingRDataLength)
+
+        /// <summary>
+        /// Parse the SvcParams that occupy the remaining RDATA of an SVCB-form
+        /// record (RFC 9460 §2.2). Shared by SVCB and HTTPS.
+        /// </summary>
+        /// <remarks>
+        /// The loop is bounded by RDLENGTH, not by the end of the stream:
+        /// RDLENGTH delimits the RDATA (RFC 1035 §4.1.3), and reading beyond it
+        /// would consume the resource record that follows — which is exactly
+        /// what happens in a real response, where an OPT record usually trails.
+        /// </remarks>
+        /// <param name="Stream">A stream positioned at the first SvcParamKey.</param>
+        /// <param name="RemainingRDataLength">The RDATA octets left after SvcPriority and TargetName.</param>
+        internal static List<SVCParameter> ParseSVCParameters(Stream  Stream,
+                                                              Int32   RemainingRDataLength)
+        {
+
+            var svcParameters  = new List<SVCParameter>();
+            var remaining      = RemainingRDataLength;
+
+            while (remaining >= 4)
+            {
+
+                var key  = Stream.ReadUInt16BE();
+                var len  = Stream.ReadUInt16BE();
+                remaining -= 4;
+
+                if (len > remaining)
+                    throw new InvalidDataException($"SvcParam {key} claims {len} bytes, but only {remaining} bytes of RDATA remain!");
+
+                var value = new Byte[len];
+                Stream.ReadExactly(value, 0, len);
+                remaining -= len;
+
+                svcParameters.Add(new SVCParameter(key, value));
+
+            }
+
+            if (remaining != 0)
+                throw new InvalidDataException($"{remaining} trailing byte(s) after the last SvcParam!");
+
+            return svcParameters;
+
+        }
+
+        #endregion
+
+
         #region Constructors
 
         #region SVCB(Stream)
@@ -163,46 +212,16 @@ namespace org.GraphDefined.Vanaheimr.Hermod.DNS
 
         {
 
-            this.Priority      = (UInt16) ((Stream.ReadByte() & byte.MaxValue) << 8 | Stream.ReadByte() & byte.MaxValue);
+            var rdLength       = Stream.ReadUInt16BE();
+            var rdataStart     = Stream.Position;
 
+            this.Priority      = Stream.ReadUInt16BE();
             this.TargetName    = DNSTools.ExtractDomainName(Stream);
 
-            var svcParameters  = new List<SVCParameter>();
-
-            while (true)
-            {
-
-                int b1 = Stream.ReadByte();
-
-                if (b1 == -1)
-                    break;
-
-                int b2 = Stream.ReadByte();
-
-                if (b2 == -1)
-                    break;
-
-                UInt16 key = (UInt16) ((b1 << 8) | b2);
-
-                b1 = Stream.ReadByte();
-
-                b2 = Stream.ReadByte();
-
-                if (b2 == -1)
-                    break;
-
-                UInt16 len = (UInt16) ((b1 << 8) | b2);
-
-                Byte[] value = new Byte[len];
-
-                if (Stream.Read(value, 0, len) != len)
-                    break;
-
-                svcParameters.Add(new SVCParameter(key, value));
-
-            }
-
-            this.SVCParameters = svcParameters.AsReadOnly();
+            this.SVCParameters = ParseSVCParameters(
+                                     Stream,
+                                     rdLength - (Int32) (Stream.Position - rdataStart)
+                                 ).AsReadOnly();
 
         }
 
@@ -224,47 +243,16 @@ namespace org.GraphDefined.Vanaheimr.Hermod.DNS
 
         {
 
-            var rdLength = Stream.ReadUInt16BE();
+            var rdLength       = Stream.ReadUInt16BE();
+            var rdataStart     = Stream.Position;
 
-            this.Priority      = (UInt16) ((Stream.ReadByte() & byte.MaxValue) << 8 | Stream.ReadByte() & byte.MaxValue);
+            this.Priority      = Stream.ReadUInt16BE();
             this.TargetName    = DNSTools.ExtractDomainName(Stream);
 
-            var svcParameters  = new List<SVCParameter>();
-
-            while (true)
-            {
-
-                int b1 = Stream.ReadByte();
-
-                if (b1 == -1)
-                    break;
-
-                int b2 = Stream.ReadByte();
-
-                if (b2 == -1)
-                    break;
-
-                UInt16 key = (UInt16) ((b1 << 8) | b2);
-
-                b1 = Stream.ReadByte();
-
-                b2 = Stream.ReadByte();
-
-                if (b2 == -1)
-                    break;
-
-                UInt16 len = (UInt16) ((b1 << 8) | b2);
-
-                Byte[] value = new Byte[len];
-
-                if (Stream.Read(value, 0, len) != len)
-                    break;
-
-                svcParameters.Add(new SVCParameter(key, value));
-
-            }
-
-            this.SVCParameters = svcParameters.AsReadOnly();
+            this.SVCParameters = ParseSVCParameters(
+                                     Stream,
+                                     rdLength - (Int32) (Stream.Position - rdataStart)
+                                 ).AsReadOnly();
 
         }
 

--- a/Hermod/DNS/ResourceRecords/TXT.cs
+++ b/Hermod/DNS/ResourceRecords/TXT.cs
@@ -109,7 +109,9 @@ namespace org.GraphDefined.Vanaheimr.Hermod.DNS
 
             var rdLength = Stream.ReadUInt16BE();
 
-            this.Text = DNSTools.ExtractCharacterString(Stream);
+            // RFC 1035 §3.3.14: TXT-DATA is "one or more <character-string>s";
+            // RFC 7208 §3.3 requires them to be concatenated without separators.
+            this.Text = String.Concat(DNSTools.ExtractCharacterStrings(Stream, rdLength));
 
         }
 
@@ -133,7 +135,9 @@ namespace org.GraphDefined.Vanaheimr.Hermod.DNS
 
             var rdLength = Stream.ReadUInt16BE();
 
-            this.Text = DNSTools.ExtractCharacterString(Stream);
+            // RFC 1035 §3.3.14: TXT-DATA is "one or more <character-string>s";
+            // RFC 7208 §3.3 requires them to be concatenated without separators.
+            this.Text = String.Concat(DNSTools.ExtractCharacterStrings(Stream, rdLength));
 
         }
 

--- a/Hermod/DNS/ResourceRecords/URI.cs
+++ b/Hermod/DNS/ResourceRecords/URI.cs
@@ -17,6 +17,8 @@
 
 #region Usings
 
+using System.Text;
+
 using org.GraphDefined.Vanaheimr.Hermod.HTTP;
 
 #endregion
@@ -124,9 +126,13 @@ namespace org.GraphDefined.Vanaheimr.Hermod.DNS
 
         {
 
-            this.Priority  = (UInt16) ((Stream.ReadByte() & byte.MaxValue) << 8 | Stream.ReadByte() & byte.MaxValue);
-            this.Weight    = (UInt16) ((Stream.ReadByte() & byte.MaxValue) << 8 | Stream.ReadByte() & byte.MaxValue);
-            this.Target    = URL.Parse(DNSTools.ExtractName(Stream));
+            var rdLength   = Stream.ReadUInt16BE();
+
+            this.Priority  = Stream.ReadUInt16BE();
+            this.Weight    = Stream.ReadUInt16BE();
+
+            // RFC 7553 §4.5: the Target is the remaining octets of the RDATA.
+            this.Target    = URL.Parse(ReadTarget(Stream, rdLength));
 
         }
 
@@ -148,11 +154,13 @@ namespace org.GraphDefined.Vanaheimr.Hermod.DNS
 
         {
 
-            var rdLength = Stream.ReadUInt16BE();
+            var rdLength   = Stream.ReadUInt16BE();
 
-            this.Priority  = (UInt16) ((Stream.ReadByte() & byte.MaxValue) << 8 | Stream.ReadByte() & byte.MaxValue);
-            this.Weight    = (UInt16) ((Stream.ReadByte() & byte.MaxValue) << 8 | Stream.ReadByte() & byte.MaxValue);
-            this.Target    = URL.Parse(DNSTools.ExtractName(Stream));
+            this.Priority  = Stream.ReadUInt16BE();
+            this.Weight    = Stream.ReadUInt16BE();
+
+            // RFC 7553 §4.5: the Target is the remaining octets of the RDATA.
+            this.Target    = URL.Parse(ReadTarget(Stream, rdLength));
 
         }
 
@@ -195,6 +203,28 @@ namespace org.GraphDefined.Vanaheimr.Hermod.DNS
         #endregion
 
 
+
+        #region (private static) ReadTarget(Stream, RDLength)
+
+        /// <summary>
+        /// Read the URI Target: the RDATA octets remaining after the 2-byte
+        /// Priority and 2-byte Weight fields (RFC 7553 §4.5).
+        /// </summary>
+        private static String ReadTarget(Stream  Stream,
+                                         UInt16  RDLength)
+        {
+
+            if (RDLength < 4)
+                throw new InvalidDataException($"URI RDATA of {RDLength} bytes is too short for Priority and Weight!");
+
+            var buffer = new Byte[RDLength - 4];
+            Stream.ReadExactly(buffer, 0, buffer.Length);
+
+            return Encoding.ASCII.GetString(buffer);
+
+        }
+
+        #endregion
 
         #region (static) TryParseFromJSON(Name, TimeToLive, Data)
 
@@ -242,29 +272,22 @@ namespace org.GraphDefined.Vanaheimr.Hermod.DNS
                                                 Dictionary<String, Int32>?  CompressionOffsets   = null)
         {
 
-            var tempStream = new MemoryStream();
+            // RFC 7553 §4.5: the Target is "the remaining octets of the RDATA"
+            // — plain octets, NOT a domain name and NOT a character-string, so
+            // it carries neither a length prefix nor label encoding, and name
+            // compression MUST NOT be applied to it.
+            var target   = Encoding.ASCII.GetBytes(Target.ToString());
 
-            tempStream.WriteUInt16BE(Priority);
-            tempStream.WriteUInt16BE(Weight);
+            var dataLen  = 2 + 2 + target.Length;
 
-            // TARGET domain-name (variable, with compression)
-            var targetOffset = (Int32) Stream.Position + 2 + (Int32) tempStream.Position;  // +2 for RDLength
-            Target.ToString().Serialize(
-                tempStream,
-                targetOffset,
-                UseCompression,
-                CompressionOffsets
-            );
-
-            if (tempStream.Length > UInt16.MaxValue)
+            if (dataLen > UInt16.MaxValue)
                 throw new InvalidOperationException("RDATA exceeds maximum UInt16 length (65535 bytes)!");
 
-            // RDLENGTH: Variable, when compression is used!
-            Stream.WriteUInt16BE(tempStream.Length);
+            Stream.WriteUInt16BE(dataLen);
 
-            // Copy RDATA to main stream
-            tempStream.Position = 0;
-            tempStream.CopyTo(Stream);
+            Stream.WriteUInt16BE(Priority);
+            Stream.WriteUInt16BE(Weight);
+            Stream.Write(target, 0, target.Length);
 
         }
 

--- a/Hermod/DNS/Server/AuthoritativeDNSRequestHandler.cs
+++ b/Hermod/DNS/Server/AuthoritativeDNSRequestHandler.cs
@@ -29,15 +29,57 @@ namespace org.GraphDefined.Vanaheimr.Hermod.DNS
 
         public Boolean  RecursionAvailable  { get; }
 
+        /// <summary>
+        /// The UDP payload size this server advertises in its own OPT record
+        /// (RFC 6891 §6.2.4). The default of 1232 bytes follows the DNS Flag Day
+        /// 2020 recommendation: it stays below common path-MTU limits, so
+        /// responses do not fragment.
+        /// </summary>
+        public UInt16   UDPPayloadSize      { get; }
+
 
         public AuthoritativeDNSRequestHandler(IDNSZoneStore  ZoneStore,
-                                              Boolean        RecursionAvailable = false)
+                                              Boolean        RecursionAvailable   = false,
+                                              UInt16         UDPPayloadSize       = 1232)
         {
 
             this.zoneStore           = ZoneStore;
             this.RecursionAvailable  = RecursionAvailable;
+            this.UDPPayloadSize      = UDPPayloadSize;
 
         }
+
+
+        #region (private) BuildResponseOPT(Request, ResponseCode)
+
+        /// <summary>
+        /// Build the OPT record for a response, or null when the request had none.
+        /// </summary>
+        /// <remarks>
+        /// RFC 6891 §6.1.1: a responder that implements EDNS "MUST include an OPT
+        /// record in their respective responses" — an EDNS query is answered with
+        /// an EDNS response. The OPT advertises this server's own payload size
+        /// (§6.2.4) and carries the upper 8 bits of an extended RCODE (§6.1.3).
+        /// Options are deliberately not echoed: unknown options MUST be ignored
+        /// (§6.1.2), and reflecting them would make the server an amplifier.
+        /// </remarks>
+        private OPT? BuildResponseOPT(DNSPacket         Request,
+                                      DNSResponseCodes  ResponseCode)
+        {
+
+            if (!Request.AdditionalRRs.OfType<OPT>().Any())
+                return null;
+
+            return new OPT(
+                       UDPPayloadSize:  UDPPayloadSize,
+                       ExtendedRCODE:   (Byte) ((Int32) ResponseCode >> 4),
+                       Version:         0,
+                       Flags:           0
+                   );
+
+        }
+
+        #endregion
 
 
         public async Task<DNSResponse?> ProcessDNSRequest(DNSPacket          Request,
@@ -47,32 +89,39 @@ namespace org.GraphDefined.Vanaheimr.Hermod.DNS
             if (Request.QueryOrResponse != DNSQueryResponse.Query)
                 return null;
 
-            if (Request.Opcode != 0)
+            DNSResponse Error(DNSResponseCodes ResponseCode)
+            {
+
+                var opt = BuildResponseOPT(Request, ResponseCode);
+
                 return Request.CreateResponse(
                            Opcode:               Request.Opcode,
                            AuthoritativeAnswer:  false,
                            Truncation:           false,
                            RecursionDesired:     Request.RecursionDesired,
                            RecursionAvailable:   RecursionAvailable,
-                           ResponseCode:         DNSResponseCodes.NotImplemented,
+                           ResponseCode:         ResponseCode,
                            AnswerRRs:            [],
                            AuthorityRRs:         [],
-                           AdditionalRRs:        []
+                           AdditionalRRs:        opt is not null ? [ opt ] : []
                        );
+
+            }
+
+            // RFC 6891 §6.1.3: "If a responder does not implement the VERSION
+            // level of the request, then it MUST respond with RCODE=BADVERS."
+            // Only EDNS version 0 is defined today.
+            var requestOPT = Request.AdditionalRRs.OfType<OPT>().FirstOrDefault();
+
+            if (requestOPT is not null && requestOPT.Version > 0)
+                return Error(DNSResponseCodes.BadVersion);
+
+            if (Request.Opcode != 0)
+                return Error(DNSResponseCodes.NotImplemented);
 
             var questions = Request.Questions.ToArray();
             if (questions.Length == 0)
-                return Request.CreateResponse(
-                           Opcode:               Request.Opcode,
-                           AuthoritativeAnswer:  false,
-                           Truncation:           false,
-                           RecursionDesired:     Request.RecursionDesired,
-                           RecursionAvailable:   RecursionAvailable,
-                           ResponseCode:         DNSResponseCodes.FormatError,
-                           AnswerRRs:            [],
-                           AuthorityRRs:         [],
-                           AdditionalRRs:        []
-                       );
+                return Error(DNSResponseCodes.FormatError);
 
             var answers            = new List<IDNSResourceRecord>();
             var authorities        = new List<IDNSResourceRecord>();
@@ -103,6 +152,12 @@ namespace org.GraphDefined.Vanaheimr.Hermod.DNS
 
             if (!foundName)
                 responseCode = DNSResponseCodes.NameError;
+
+            // RFC 6891 §6.1.1: mirror EDNS by carrying an OPT in the response.
+            var responseOPT = BuildResponseOPT(Request, responseCode);
+
+            if (responseOPT is not null)
+                additionalRecords.Add(responseOPT);
 
             return Request.CreateResponse(
                        Opcode:               Request.Opcode,

--- a/Hermod/DNS/Server/DNSServer.cs
+++ b/Hermod/DNS/Server/DNSServer.cs
@@ -151,6 +151,174 @@ namespace org.GraphDefined.Vanaheimr.Hermod.DNS
         #endregion
 
 
+        #region (private static) BuildFormatErrorResponse(RequestBytes)
+
+        /// <summary>
+        /// Build a minimal FORMERR reply for a request that could not be parsed,
+        /// or null when even that is not possible.
+        /// </summary>
+        /// <remarks>
+        /// RFC 1035 §4.1.1 defines RCODE 1 as "the name server was unable to
+        /// interpret the query". Only the 12-byte header is needed: the
+        /// transaction id is echoed from the first two octets, which stay
+        /// readable however mangled the rest of the message is. Answering lets a
+        /// client tell "malformed request" from "server unreachable" instead of
+        /// retrying blindly.
+        /// </remarks>
+        private static Byte[]? BuildFormatErrorResponse(Byte[] RequestBytes)
+        {
+
+            // Too short to even echo a transaction id — stay silent.
+            if (RequestBytes.Length < 12)
+                return null;
+
+            // Never answer something that is itself a response: two servers
+            // exchanging error replies would loop.
+            if ((RequestBytes[2] & 0x80) != 0)
+                return null;
+
+            var opcode = (Byte) ((RequestBytes[2] >> 3) & 0x0F);
+
+            return [
+
+                       RequestBytes[0],                          // transaction id, echoed
+                       RequestBytes[1],
+
+                       (Byte) (0x80 |                            // QR = 1
+                               (opcode << 3) |                   // opcode, echoed
+                               (RequestBytes[2] & 0x01)),        // RD, echoed
+
+                       (Byte) DNSResponseCodes.FormatError,      // RCODE = 1
+
+                       // The question could not be parsed, so no section is echoed.
+                       0, 0,                                     // QDCOUNT
+                       0, 0,                                     // ANCOUNT
+                       0, 0,                                     // NSCOUNT
+                       0, 0                                      // ARCOUNT
+
+                   ];
+
+        }
+
+        #endregion
+
+        #region (private) Serialize               (Response)
+
+        private Byte[] Serialize(DNSPacket Response)
+        {
+
+            var memoryStream = new MemoryStream();
+
+            Response.Serialize(
+                memoryStream,
+                UseCompression:      Options.UseCompression,
+                CompressionOffsets:  []
+            );
+
+            return memoryStream.ToArray();
+
+        }
+
+        #endregion
+
+        #region (private) SerializeForUDP         (Response, Request)
+
+        /// <summary>
+        /// Serialize a response for transmission over UDP, truncating it when it
+        /// does not fit into the requestor's buffer.
+        /// </summary>
+        /// <remarks>
+        /// RFC 1035 §4.2.1: "Messages carried by UDP are restricted to 512 bytes.
+        /// Longer messages are truncated and the TC bit is set in the header."
+        /// RFC 6891 §6.2.3 raises that ceiling to whatever the requestor advertises
+        /// in its OPT record (values below 512 are treated as 512), and §6.2.5
+        /// forbids exceeding it. Answer records are shed until the message fits;
+        /// the OPT record is kept so the response stays EDNS-conformant.
+        /// </remarks>
+        private Byte[] SerializeForUDP(DNSResponse  Response,
+                                       DNSPacket    Request)
+        {
+
+            var full = Serialize(Response);
+
+            var requestOPT  = Request.AdditionalRRs.OfType<OPT>().FirstOrDefault();
+
+            var limit       = requestOPT is not null
+                                  ? Math.Min(Math.Max(requestOPT.UDPPayloadSize, (UInt16) 512), Options.MaxUDPResponseSize)
+                                  : 512;
+
+            if (full.Length <= limit)
+                return full;
+
+            var answers      = Response.AnswerRRs.ToArray();
+            var responseOPT  = Response.AdditionalRRs.OfType<OPT>().Cast<IDNSResourceRecord>().ToArray();
+
+            // Drop answer records from the end until the message fits. Authority
+            // and additional sections go entirely, except for the OPT record.
+            for (var count = answers.Length - 1; count >= 0; count--)
+            {
+
+                var truncated = new DNSResponse(
+                                    Request:               Request,
+                                    TransactionId:         Response.TransactionId,
+                                    QueryOrResponse:       DNSQueryResponse.Response,
+                                    Opcode:                Response.Opcode,
+                                    AuthoritativeAnswer:   Response.AuthoritativeAnswer,
+                                    Truncation:            true,
+                                    RecursionDesired:      Response.RecursionDesired,
+                                    RecursionAvailable:    Response.RecursionAvailable,
+                                    ResponseCode:          Response.ResponseCode,
+                                    Questions:             Response.Questions,
+                                    AnswerRRs:             answers.Take(count).ToArray(),
+                                    AuthorityRRs:          [],
+                                    AdditionalRRs:         responseOPT
+                                );
+
+                var bytes = Serialize(truncated);
+
+                if (bytes.Length <= limit)
+                {
+
+                    logger.LogDebug(
+                        "Truncating a {FullLength}-byte UDP response to {TruncatedLength} bytes ({KeptAnswers} of {TotalAnswers} answers, limit {Limit})",
+                        full.Length,
+                        bytes.Length,
+                        count,
+                        answers.Length,
+                        limit
+                    );
+
+                    return bytes;
+
+                }
+
+            }
+
+            // Even the bare header + question exceeds the limit: send it anyway,
+            // flagged truncated, so the client knows to retry over TCP.
+            return Serialize(
+                       new DNSResponse(
+                           Request:               Request,
+                           TransactionId:         Response.TransactionId,
+                           QueryOrResponse:       DNSQueryResponse.Response,
+                           Opcode:                Response.Opcode,
+                           AuthoritativeAnswer:   Response.AuthoritativeAnswer,
+                           Truncation:            true,
+                           RecursionDesired:      Response.RecursionDesired,
+                           RecursionAvailable:    Response.RecursionAvailable,
+                           ResponseCode:          Response.ResponseCode,
+                           Questions:             Response.Questions,
+                           AnswerRRs:             [],
+                           AuthorityRRs:          [],
+                           AdditionalRRs:         []
+                       )
+                   );
+
+        }
+
+        #endregion
+
+
         // ToDo: To well-known problems when listing on localhost IPv4+IPv6,
         //       we might need separate listeners for IPv4 and IPv6!
 
@@ -180,13 +348,39 @@ namespace org.GraphDefined.Vanaheimr.Hermod.DNS
                 try
                 {
 
-                    var dnsPacket   = await udpUnicastListener.ReceiveAsync(CancellationToken);
+                    var dnsPacket = await udpUnicastListener.ReceiveAsync(CancellationToken);
 
-                    var dnsRequest  = DNSPacket.Parse(
-                                          ActiveUDPUnicastSocket ?? localSocket,
-                                          IPSocket.FromIPEndPoint(dnsPacket.RemoteEndPoint),
-                                          new MemoryStream(dnsPacket.Buffer)
-                                      );
+                    DNSPacket dnsRequest;
+
+                    try
+                    {
+                        dnsRequest = DNSPacket.Parse(
+                                         ActiveUDPUnicastSocket ?? localSocket,
+                                         IPSocket.FromIPEndPoint(dnsPacket.RemoteEndPoint),
+                                         new MemoryStream(dnsPacket.Buffer)
+                                     );
+                    }
+                    catch (Exception parseException)
+                    {
+
+                        logger.LogDebug(
+                            parseException,
+                            "Could not parse a DNS request from {RemoteEndPoint}; answering FORMERR",
+                            dnsPacket.RemoteEndPoint
+                        );
+
+                        var formatError = BuildFormatErrorResponse(dnsPacket.Buffer);
+
+                        if (formatError is not null)
+                            await udpUnicastListener.SendAsync(
+                                      new ReadOnlyMemory<Byte>(formatError),
+                                      dnsPacket.RemoteEndPoint,
+                                      CancellationToken
+                                  );
+
+                        continue;
+
+                    }
 
                     await LogEvent(
                         OnDNSRequestReceived,
@@ -205,16 +399,8 @@ namespace org.GraphDefined.Vanaheimr.Hermod.DNS
                     if (dnsResponse is not null)
                     {
 
-                        var memoryStream = new MemoryStream();
-
-                        dnsResponse.Serialize(
-                            memoryStream,
-                            UseCompression:      Options.UseCompression,
-                            CompressionOffsets:  []
-                        );
-
                         await udpUnicastListener.SendAsync(
-                                  new ReadOnlyMemory<Byte>(memoryStream.ToArray()),
+                                  new ReadOnlyMemory<Byte>(SerializeForUDP(dnsResponse, dnsRequest)),
                                   dnsResponse.RemoteSocket.ToIPEndPoint(),
                                   CancellationToken
                               );
@@ -307,17 +493,9 @@ namespace org.GraphDefined.Vanaheimr.Hermod.DNS
                     if (dnsResponse is not null)
                     {
 
-                        var memoryStream = new MemoryStream();
-
-                        dnsResponse.Serialize(
-                            memoryStream,
-                            UseCompression:      Options.UseCompression,
-                            CompressionOffsets:  []
-                        );
-
                         // Multicast response via unicast back to the sender!
                         await udpMulticastListener.SendAsync(
-                                  new ReadOnlyMemory<Byte>(memoryStream.ToArray()),
+                                  new ReadOnlyMemory<Byte>(SerializeForUDP(dnsResponse, dnsRequest)),
                                   dnsResponse.RemoteSocket.ToIPEndPoint(),
                                   CancellationToken
                               );

--- a/Hermod/DNS/Server/DNSServerOptions.cs
+++ b/Hermod/DNS/Server/DNSServerOptions.cs
@@ -66,6 +66,15 @@ namespace org.GraphDefined.Vanaheimr.Hermod.DNS
 
         public Boolean   UseCompression         { get; init; } = false;
 
+        /// <summary>
+        /// The largest UDP response this server will emit, even when a requestor
+        /// advertises a bigger EDNS0 buffer. The default of 1232 bytes follows the
+        /// DNS Flag Day 2020 recommendation and keeps responses below common path
+        /// MTUs, so they do not fragment. Larger answers are truncated with TC=1,
+        /// which tells the client to retry over TCP (RFC 1035 §4.2.1).
+        /// </summary>
+        public UInt16    MaxUDPResponseSize     { get; init; } = 1232;
+
     }
 
 }


### PR DESCRIPTION
Every fix here was found by an independent test suite that measures this stack against the RFCs and against BIND, Knot, ldns and the public resolvers, rather than against Hermod's own idea of the protocol.

Three of these are the same mistake in three places. RFC 1035 4.1.3 makes RDLENGTH the definitive extent of a record's RDATA, and three parsers ignored it, reading until the *stream* ended instead. That works only when the record happens to be last in the message -- true in a unit test, false in real traffic, where an OPT record almost always trails. The symptom is not a mangled record but a mangled message: the over-reading parser eats the next record's bytes and everything after it is lost. That is why a live cloudflare.com/HTTPS query failed with SERVFAIL instead of returning a partly-wrong answer.

  TXT, SPF (RFC 1035 3.3.14, RFC 7208 3.3)
    Only the first character-string was read, so any TXT above 255 bytes was
    truncated -- precisely the population (DKIM keys, long SPF policies,
    DMARC) that exceeds 255 bytes. Serialization was already correct, so
    Hermod could emit a record it could not read back. SPF was worse: it
    decoded its text with the domain-name parser, so every '.' in a policy
    became a label boundary. Both now use a new RDLENGTH-bounded
    DNSTools.ExtractCharacterStrings and concatenate the result.

  URI (RFC 7553 4.5)
    The target is "the remaining octets of the RDATA" -- not a domain name and
    not a character-string. Both directions went through the domain-name
    codec, so https://www.example.com/path was written as length-prefixed
    labels. Now written and read as raw octets, with no name compression.

  SVCB, HTTPS (RFC 1035 4.1.3, RFC 9460 2.2)
    The SvcParam loop ran to end-of-stream. Replaced by one shared
    SVCB.ParseSVCParameters bounded by RDLENGTH, used by all four stream
    constructors -- two of which never read RDLENGTH at all. It also rejects a
    SvcParam claiming more bytes than remain, and trailing bytes after the
    last param.

  DNSUDPClient (RFC 5452 4.2)
    A resolver MUST ignore responses that do not match the outstanding query.
    Hermod rejected a wrong transaction id correctly, but a single
    ReceiveAsync meant the first datagram ended the query whether or not it
    was accepted, and the genuine reply arriving microseconds later was never
    read. That inverts the requirement: instead of shrugging off forged
    packets, any off-path attacker who lands one datagram achieves a denial of
    service, cheaper and more reliably than winning a poisoning race. The
    client now loops on receive, discarding non-matching datagrams until a
    match arrives or the existing timeout expires.

  AuthoritativeDNSRequestHandler (RFC 6891 6.1.1, 6.1.3)
    Responses to EDNS queries carried no OPT record, so a requestor could not
    tell whether the server spoke EDNS nor learn its payload size, and
    dig +edns=1 got NOERROR where BADVERS was required. Adds
    DNSResponseCodes.BadVersion = 16 and attaches an OPT whenever the query
    carried one, advertising the server's own payload size and carrying the
    upper 8 bits of an extended RCODE. Options are deliberately not echoed:
    unknown options MUST be ignored (6.1.2), and reflecting them would make
    the server an amplifier.

  DNSServer UDP size discipline (RFC 1035 4.2.1, RFC 6891 6.2.5)
    A 600-byte TXT produced a 673-byte UDP response with TC=0, both without
    EDNS and with EDNS advertising 512. Such datagrams fragment or are dropped
    by middleboxes, and with TC clear the client was never told to retry over
    TCP, so the answer simply vanished. SerializeForUDP now sheds answer
    records until the message fits under min(advertised, MaxUDPResponseSize)
    -- 512 without EDNS -- and sets TC=1, keeping the OPT record. Applied to
    both the unicast and multicast paths.

  DNSServer FORMERR (RFC 1035 4.1.1)
    Unparseable requests were logged and dropped, so a client could not tell
    "malformed request" from "server down" and retried blindly. The parse is
    now its own try; on failure the server answers FORMERR built from the
    first two octets, which stay readable however mangled the rest is.
    Datagrams under 12 bytes are ignored, and anything with QR already set is
    never answered, so two servers cannot ping-pong error replies.

Not addressed here: query names are lowercased before reaching the wire (RFC 1035 2.3.3, SHOULD-level). The fix belongs in DomainName / DNSServiceName, which are used well beyond DNS wire encoding, so it wants its own review. The practical cost is that dns-0x20 query randomization cannot be built on the current types.

Verified by 211 conformance and interoperability tests (offline, WSL tooling, and live public resolvers), plus 89 of Hermod's own DNS tests for regressions.