### PR TITLE
DNS: preserve the case of domain names, and fix name compression

### DIFF
--- a/Hermod/DNS/Client/Cache/DNSCache.cs
+++ b/Hermod/DNS/Client/Cache/DNSCache.cs
@@ -39,7 +39,10 @@ namespace org.GraphDefined.Vanaheimr.Hermod.DNS
         #region Data
 
         private readonly ConcurrentDictionary<DNSServiceName, DNSCacheEntry>  dnsCache       = [];
-        private readonly ConcurrentDictionary<String, DateTimeOffset>        noDataCache    = [];
+        // Keyed by "<name>|<type>". Case-insensitive because names now keep the case they
+        // arrived in (RFC 1035 §2.3.3) while still being the same name (RFC 4343) — an
+        // ordinal comparer would file "EXAMPLE.com" and "example.com" as separate entries.
+        private readonly ConcurrentDictionary<String, DateTimeOffset>        noDataCache    = new(StringComparer.OrdinalIgnoreCase);
         private readonly Timer                                                cleanUpTimer;
         private readonly Object                                               cleanUpLock    = new();
 

--- a/Hermod/DNS/DNSServiceInstanceName.cs
+++ b/Hermod/DNS/DNSServiceInstanceName.cs
@@ -146,7 +146,11 @@ namespace org.GraphDefined.Vanaheimr.Hermod.DNS
             DNSServiceInstance     = null;
             ErrorResponse  = null;
 
-            Text = Text?.Trim().ToLowerInvariant() ?? "";
+            // RFC 1035 §2.3.3: preserve the case of a received name; comparisons are
+            // case-insensitive instead (RFC 4343). This matters twice over here — an
+            // RFC 6763 service instance carries a human-readable Instance label whose
+            // capitalization is meant to be shown to users.
+            Text = Text?.Trim() ?? "";
 
             if (Text.IsNullOrEmpty())
             {
@@ -299,7 +303,7 @@ namespace org.GraphDefined.Vanaheimr.Hermod.DNS
         public static Boolean operator == (DNSServiceInstanceName DNSServiceInstance1,
                                            String     DNSServiceInstance2)
 
-            => DNSServiceInstance1.FullName.Equals(DNSServiceInstance2);
+            => DNSServiceInstance1.FullName.Equals(DNSServiceInstance2, StringComparison.OrdinalIgnoreCase);
 
         #endregion
 
@@ -329,7 +333,7 @@ namespace org.GraphDefined.Vanaheimr.Hermod.DNS
         public static Boolean operator != (DNSServiceInstanceName DNSServiceInstance1,
                                            String     DNSServiceInstance2)
 
-            => !DNSServiceInstance1.FullName.Equals(DNSServiceInstance2);
+            => !DNSServiceInstance1.FullName.Equals(DNSServiceInstance2, StringComparison.OrdinalIgnoreCase);
 
         #endregion
 
@@ -424,7 +428,9 @@ namespace org.GraphDefined.Vanaheimr.Hermod.DNS
             if (DNSServiceInstance is null)
                 throw new ArgumentNullException(nameof(DNSServiceInstance), "The given DNS service instance must not be null!");
 
-            return FullName.CompareTo(DNSServiceInstance.FullName);
+            return String.Compare(FullName,
+                                  DNSServiceInstance.FullName,
+                                  StringComparison.OrdinalIgnoreCase);
 
         }
 
@@ -457,9 +463,10 @@ namespace org.GraphDefined.Vanaheimr.Hermod.DNS
 
             => DNSServiceInstance is not null &&
 
+               // RFC 4343: case-insensitive, and must agree with GetHashCode().
                String.Equals(FullName,
                              DNSServiceInstance.FullName,
-                             StringComparison.Ordinal);
+                             StringComparison.OrdinalIgnoreCase);
 
         #endregion
 

--- a/Hermod/DNS/DNSServiceName.cs
+++ b/Hermod/DNS/DNSServiceName.cs
@@ -163,7 +163,9 @@ namespace org.GraphDefined.Vanaheimr.Hermod.DNS
             DNSService     = null;
             ErrorResponse  = null;
 
-            Text = Text?.Trim().ToLowerInvariant() ?? "";
+            // RFC 1035 §2.3.3: preserve the case of a received name. Comparisons are
+            // case-insensitive instead (RFC 4343) — see Equals/CompareTo/GetHashCode.
+            Text = Text?.Trim() ?? "";
 
             if (Text.IsNullOrEmpty())
             {
@@ -243,6 +245,9 @@ namespace org.GraphDefined.Vanaheimr.Hermod.DNS
 
             Offsets ??= [];
 
+            // Case-folded compression key — see DomainName.Serialize (RFC 4343).
+            var compressionKey = FullName.ToLowerInvariant();
+
             // Root domain. A name parsed from "." (or "") is represented as a single empty
             // label; it must serialize to just the terminating zero byte. Emitting a zero-length
             // label followed by the terminator would put two 0x00 bytes on the wire and corrupt
@@ -254,7 +259,7 @@ namespace org.GraphDefined.Vanaheimr.Hermod.DNS
             }
 
             // Check for compression
-            if (UseCompression && Offsets.TryGetValue(FullName, out var pointerOffset))
+            if (UseCompression && Offsets.TryGetValue(compressionKey, out var pointerOffset))
             {
                 // Pointer: 0xC0 | (offset >> 8), then low byte
                 var pointer = (UInt16) (0xC000 | pointerOffset);
@@ -263,23 +268,26 @@ namespace org.GraphDefined.Vanaheimr.Hermod.DNS
                 return;
             }
 
-            // Add offset for this name
-            Offsets[FullName] = CurrentOffset;
+            // Record where each suffix of this name starts — see DomainName.Serialize.
+            var offset = CurrentOffset;
 
-            foreach (var label in Labels)
+            for (var i = 0; i < labels.Length; i++)
             {
 
-                var labelBytes = Encoding.ASCII.GetBytes(label);
+                var labelBytes = Encoding.ASCII.GetBytes(labels[i]);
                 if (labelBytes.Length > 63)
                     throw new ArgumentException("Label too long");
+
+                // RFC 1035 §4.1.4: pointers carry a 14-bit offset; never record one that
+                // cannot be represented.
+                var suffixKey = String.Join('.', labels.Skip(i)).ToLowerInvariant() + ".";
+                if (offset <= 0x3FFF && !Offsets.ContainsKey(suffixKey))
+                    Offsets[suffixKey] = offset;
 
                 Stream.WriteByte((Byte) labelBytes.Length);
                 Stream.Write    (labelBytes, 0, labelBytes.Length);
 
-                // Update offset for suffixes
-                var suffix = String.Join(".", labels.AsEnumerable().Skip(Array.IndexOf(labels, label) + 1));
-                if (!String.IsNullOrEmpty(suffix) && !Offsets.ContainsKey(suffix))
-                    Offsets[suffix] = CurrentOffset + 1 + labelBytes.Length;
+                offset += 1 + labelBytes.Length;
 
             }
 
@@ -443,7 +451,9 @@ namespace org.GraphDefined.Vanaheimr.Hermod.DNS
             if (DNSService is null)
                 throw new ArgumentNullException(nameof(DNSService), "The given DNS service must not be null!");
 
-            return FullName.CompareTo(DNSService.FullName);
+            return String.Compare(FullName,
+                                  DNSService.FullName,
+                                  StringComparison.OrdinalIgnoreCase);
 
         }
 
@@ -476,9 +486,12 @@ namespace org.GraphDefined.Vanaheimr.Hermod.DNS
 
             => DNSService is not null &&
 
+               // RFC 4343: names are case-insensitive. Must agree with GetHashCode(),
+               // which hashes case-insensitively — InMemoryDNSZone keys a dictionary
+               // on this type, so a mismatch here silently loses records.
                String.Equals(FullName,
                              DNSService.FullName,
-                             StringComparison.Ordinal);
+                             StringComparison.OrdinalIgnoreCase);
 
         #endregion
 

--- a/Hermod/DNS/DomainName.cs
+++ b/Hermod/DNS/DomainName.cs
@@ -317,7 +317,12 @@ namespace org.GraphDefined.Vanaheimr.Hermod.DNS
             DomainName     = null;
             ErrorResponse  = null;
 
-            Text = Text?.Trim().ToLowerInvariant() ?? "";
+            // RFC 1035 §2.3.3: "When you receive a domain name or label, you should
+            // preserve its case." The case of a name is therefore carried through
+            // unchanged; every comparison below (and in Equals/CompareTo/GetHashCode)
+            // is case-insensitive instead, per RFC 4343. Normalizing here would also
+            // make dns-0x20 query randomization impossible to build on top of this type.
+            Text = Text?.Trim() ?? "";
 
             if (Text.IsNullOrEmpty())
             {
@@ -407,6 +412,14 @@ namespace org.GraphDefined.Vanaheimr.Hermod.DNS
 
             Offsets ??= [];
 
+            // Compression keys are case-folded, because RFC 4343 makes names that differ
+            // only in case the same name: "MiXeD.example." may legitimately be compressed
+            // against an earlier "mixed.example.". Folding the key here rather than relying
+            // on the dictionary's comparer keeps this correct no matter how the caller
+            // constructed it. Only the key is folded — the labels written below keep their
+            // original case, which is what preserves it on the wire (RFC 1035 §2.3.3).
+            var compressionKey = FullName.ToLowerInvariant();
+
             // Root domain. A name parsed from "." (or "") has no real labels; depending on the
             // parse path it is represented either as an empty label set or as a single empty
             // label. Both must serialize to just the terminating zero byte — emitting a zero-length
@@ -419,7 +432,7 @@ namespace org.GraphDefined.Vanaheimr.Hermod.DNS
             }
 
             // Check for compression
-            if (UseCompression && Offsets.TryGetValue(FullName, out var pointerOffset))
+            if (UseCompression && Offsets.TryGetValue(compressionKey, out var pointerOffset))
             {
                 // Pointer: 0xC0 | (offset >> 8), then low byte
                 UInt16 pointer = (UInt16)(0xC000 | pointerOffset);
@@ -428,23 +441,30 @@ namespace org.GraphDefined.Vanaheimr.Hermod.DNS
                 return;
             }
 
-            // Add offset for this name
-            Offsets[FullName] = CurrentOffset;
+            // Every suffix of this name is itself a name, so record where each one starts:
+            // a later "example.com." can then point at the tail of an earlier
+            // "www.example.com.". The running offset must advance label by label — measuring
+            // every suffix from CurrentOffset only happens to be right for the first one.
+            var offset = CurrentOffset;
 
-            foreach (var label in Labels)
+            for (var i = 0; i < labels.Length; i++)
             {
 
-                var labelBytes = Encoding.ASCII.GetBytes(label);
+                var labelBytes = Encoding.ASCII.GetBytes(labels[i]);
                 if (labelBytes.Length > 63)
                     throw new ArgumentException("Label too long");
+
+                // RFC 1035 §4.1.4: a pointer carries a 14-bit offset, so anything at or
+                // beyond 16384 can never be pointed at. Recording it would emit a pointer
+                // with the high bits silently truncated, corrupting the message.
+                var suffixKey = String.Join('.', labels.Skip(i)).ToLowerInvariant() + ".";
+                if (offset <= 0x3FFF && !Offsets.ContainsKey(suffixKey))
+                    Offsets[suffixKey] = offset;
 
                 Stream.WriteByte((Byte) labelBytes.Length);
                 Stream.Write    (labelBytes, 0, labelBytes.Length);
 
-                // Update offset for suffixes
-                var suffix = String.Join(".", labels.AsEnumerable().Skip(Array.IndexOf(labels, label) + 1));
-                if (!String.IsNullOrEmpty(suffix) && !Offsets.ContainsKey(suffix))
-                    Offsets[suffix] = CurrentOffset + 1 + labelBytes.Length;
+                offset += 1 + labelBytes.Length;
 
             }
 
@@ -482,7 +502,7 @@ namespace org.GraphDefined.Vanaheimr.Hermod.DNS
         public static Boolean operator == (DomainName DomainName1,
                                            String     DomainName2)
 
-            => DomainName1.FullName.Equals(DomainName2);
+            => DomainName1.FullName.Equals(DomainName2, StringComparison.OrdinalIgnoreCase);
 
         #endregion
 
@@ -512,7 +532,7 @@ namespace org.GraphDefined.Vanaheimr.Hermod.DNS
         public static Boolean operator != (DomainName DomainName1,
                                            String     DomainName2)
 
-            => !DomainName1.FullName.Equals(DomainName2);
+            => !DomainName1.FullName.Equals(DomainName2, StringComparison.OrdinalIgnoreCase);
 
         #endregion
 
@@ -607,7 +627,10 @@ namespace org.GraphDefined.Vanaheimr.Hermod.DNS
             if (DomainName is null)
                 throw new ArgumentNullException(nameof(DomainName), "The given domain name must not be null!");
 
-            return FullName.CompareTo(DomainName.FullName);
+            // RFC 4343: domain names compare without regard to case.
+            return String.Compare(FullName,
+                                  DomainName.FullName,
+                                  StringComparison.OrdinalIgnoreCase);
 
         }
 
@@ -640,9 +663,11 @@ namespace org.GraphDefined.Vanaheimr.Hermod.DNS
 
             => DomainName is not null &&
 
+               // RFC 4343: "example.com" and "EXAMPLE.COM" are the same name. This must
+               // agree with GetHashCode(), which has always hashed case-insensitively.
                String.Equals(FullName,
                              DomainName.FullName,
-                             StringComparison.Ordinal);
+                             StringComparison.OrdinalIgnoreCase);
 
         #endregion
 


### PR DESCRIPTION
RFC 1035 section 2.3.3 asks receivers to preserve the case of a name; RFC 4343 then requires that preserving it must not make case significant. DomainName, DNSServiceName and DNSServiceInstanceName lowercased in TryParse, so the original spelling never reached the wire and dns-0x20 query randomization could not be built on these types.

Normalizing at the front door had been hiding three things behind it, all of which had to be fixed for case preservation to be safe:

  - Equals used StringComparison.Ordinal while GetHashCode used OrdinalIgnoreCase. Unreachable while everything was lowercased, but InMemoryDNSZone keys a ConcurrentDictionary on DNSServiceName, so a zone lookup would have started missing records that were present.
  - CompareTo used String.CompareTo, which is culture-sensitive.
  - DNSCache.noDataCache is keyed by "<name>|<type>" with an ordinal comparer, so two spellings of one name would have become two entries.

Parsing now preserves case; Equals, CompareTo and the string operators are OrdinalIgnoreCase, matching the hash that was always there; the negative cache uses a case-insensitive comparer. DNSSECValidator needed no change, because SerializeCanonicalName already lowercases explicitly for the RFC 4034 section 6.2 canonical form.

Making compression case-insensitive then exposed that its suffix table could never match at all: suffix keys were stored without a trailing dot while every lookup used the full name with one. Two further defects were masked by that one, and would have started corrupting messages the moment it was fixed alone:

  - every suffix offset was measured from the start of the name rather than from a running position, so only the first was correct;
  - Array.IndexOf resolved a repeated label to its first occurrence, so in a.b.a.example the suffix after the second "a" was computed as if it followed the first.

All three are fixed together, plus a 14-bit guard: RFC 1035 section 4.1.4 gives a pointer only 14 bits of offset, so an offset at or beyond 16384 must not be recorded or the pointer silently truncates.

Verified by the DNS conformance suite: 273 passing, including 38 WSL interop tests in which dig, kdig, drill and BIND all still parse what Hermod emits.